### PR TITLE
Resize images displayed in article-link.html

### DIFF
--- a/layouts/partials/article-link.html
+++ b/layouts/partials/article-link.html
@@ -30,9 +30,9 @@
     {{- $featured := $images.GetMatch "*feature*" -}}
     {{- if not $featured }}{{ $featured = $images.GetMatch "{*cover*,*thumbnail*}" }}{{ end -}}
     {{- with $featured -}}
-
-    <div class="{{ $articleImageClasses }}" style="background-image:url({{ $featured.Permalink }});"></div>
-
+      {{ with .Resize "600x" }}
+    <div class="{{ $articleImageClasses }}" style="background-image:url({{ .RelPermalink }});"></div>
+      {{ end }}
     {{- else -}}
     {{- with $.Site.Params.images }}
     <meta property="og:image" content="{{ index . 0 | absURL }}" />{{ end -}}


### PR DESCRIPTION
Currently the images are displayed at their full resolution. Those images could be very large, but end up being displayed as 300px wide. This changes that by resizing those images to a more suitable size.